### PR TITLE
Avoid collision in responses context

### DIFF
--- a/docs/microbot.rst
+++ b/docs/microbot.rst
@@ -6,6 +6,7 @@ Subpackages
 
 .. toctree::
 
+    microbot.migrations
     microbot.models
     microbot.test
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,9 +17,14 @@ required field. Add webhook url to your urlpatterns::
 Define handlers for each bot to define how your bot react to client messages. A handler is defined with:
 
 	* Pattern: regex expression as a django url pattern
-	* Response text template: Jinja2 template to generate text message as response
-	* Response keyboard template: Jinja2 template to generate keyboard as response
+	* Response text template: `Jinja2` template to generate text message as response
+	* Response keyboard template: `Jinja2` template to generate keyboard as response
 	* Request: request to an API with the application logic. The returned data is used as context to generate response.
+	
+In order to avoid collisions, context for responses (text and keyboard) are generated with two basic vars, `url` and `response`. In the case 
+of obtaining a list of elements as GET response the way of accessing is `response.list`.
+
+
 
 
 

--- a/microbot/models/handler.py
+++ b/microbot/models/handler.py
@@ -64,8 +64,8 @@ class Handler(models.Model):
     def urlpattern(self):
         return url(self.pattern, self.process)
     
-    def process(self, bot, update, **context):
-        r = self.request.process(**context)
+    def process(self, bot, update, **url_context):
+        r = self.request.process(**url_context)
         response_text_template = Template(self.response_text_template)
         try:
             response_context = r.json()
@@ -73,10 +73,12 @@ class Handler(models.Model):
                 response_context = {"list": response_context}
         except:
             response_context = {}
-        response_text = response_text_template.render(**response_context)
+        context = {'url': url_context,
+                   'response': response_context}
+        response_text = response_text_template.render(**context)
         if self.response_keyboard_template:
             response_keyboard_template = Template(self.response_keyboard_template)
-            response_keyboard = response_keyboard_template.render(**r.json())
+            response_keyboard = response_keyboard_template.render(**context)
         else:
             response_keyboard = None
         return response_text, response_keyboard

--- a/tests/test_microbot.py
+++ b/tests/test_microbot.py
@@ -99,7 +99,7 @@ class TestPost(LiveServerTestCase, testcases.BaseTestBot):
     author_delete_pattern = {'in': '/authors_delete@1',
                              'out': {'parse_mode': 'HTML',
                                      'reply_markup': '',
-                                     'text': 'Author deleted'
+                                     'text': 'Author 1 deleted'
                                      }
                              }
     
@@ -110,7 +110,7 @@ class TestPost(LiveServerTestCase, testcases.BaseTestBot):
         self.handler = factories.HandlerFactory(bot=self.bot,
                                                 pattern='/authors',
                                                 request=self.request,
-                                                response_text_template='{% for author in list %}<b>{{author.name}}</b>{% endfor %}',
+                                                response_text_template='{% for author in response.list %}<b>{{author.name}}</b>{% endfor %}',
                                                 response_keyboard_template='')
         self._test_message(self.author_get)
  
@@ -120,7 +120,7 @@ class TestPost(LiveServerTestCase, testcases.BaseTestBot):
                                                 method=Request.GET)
         self.handler = factories.HandlerFactory(bot=self.bot,
                                                 pattern='/authors@(?P<id>\d+)',
-                                                response_text_template='<b>{{name}}</b>',
+                                                response_text_template='<b>{{response.name}}</b>',
                                                 response_keyboard_template='',
                                                 request=self.request)
         self._test_message(self.author_get_pattern)
@@ -133,7 +133,7 @@ class TestPost(LiveServerTestCase, testcases.BaseTestBot):
         self.handler = factories.HandlerFactory(bot=self.bot,
                                                 pattern='/authors',
                                                 request=self.request,
-                                                response_text_template='<b>{{name}}</b> created',
+                                                response_text_template='<b>{{response.name}}</b> created',
                                                 response_keyboard_template='')
         self._test_message(self.author_post_pattern)
         self.assertEqual(Author.objects.count(), 1)
@@ -149,7 +149,7 @@ class TestPost(LiveServerTestCase, testcases.BaseTestBot):
         self.handler = factories.HandlerFactory(bot=self.bot,
                                                 pattern='/authors@(?P<id>\d+)',
                                                 request=self.request,
-                                                response_text_template='<b>{{name}}</b> updated',
+                                                response_text_template='<b>{{response.name}}</b> updated',
                                                 response_keyboard_template='')
         self._test_message(self.author_put_pattern)
         self.assertEqual(Author.objects.count(), 1)
@@ -163,7 +163,7 @@ class TestPost(LiveServerTestCase, testcases.BaseTestBot):
         self.handler = factories.HandlerFactory(bot=self.bot,
                                                 pattern='/authors_delete@(?P<id>\d+)',
                                                 request=self.request,
-                                                response_text_template='Author deleted',
+                                                response_text_template='Author {{ url.id }} deleted',
                                                 response_keyboard_template='')
         self._test_message(self.author_delete_pattern)
         self.assertEqual(Author.objects.count(), 0)


### PR DESCRIPTION
In order of avoid collision when passing context to Jinja2 template in responses, separated in two vars the context from url pattern `url` and the one from request response `response`.
i.e. `{{url.id}}` or `{{ response.name }}`
